### PR TITLE
Bus Factor Implementation for GitHub URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,5 @@ run:
 # 	jest
 
 # Remove current compiled project files
-clean: rm -rf $(OUT_DIR)
+clean: 
+	rm -rf $(OUT_DIR)

--- a/dist/commands/analyze.js
+++ b/dist/commands/analyze.js
@@ -1,7 +1,0 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.analyze = void 0;
-const analyze = (packageURL) => {
-    console.log(`Fetching security metrics for package: ${packageURL}`);
-};
-exports.analyze = analyze;

--- a/dist/commands/install.js
+++ b/dist/commands/install.js
@@ -1,7 +1,0 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.install = void 0;
-const install = () => {
-    console.log("Installing dependencies...");
-};
-exports.install = install;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -1,3 +1,7 @@
-export const analyze = (packageURL: string) => {
+import { getBusFactor } from '../models/busFactor.js';
+
+export const analyze = async (packageURL: string) => {
     console.log(`Fetching security metrics for package: ${packageURL}`);
+    const busFactor = await getBusFactor(packageURL);
+    console.log(`Bus factor for package: ${busFactor}`);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 // Main entry point TypeScript file
 import dotenv from 'dotenv';
-import path from 'path';
-import { program } from './utils/cli';
+import path, { dirname } from 'path';
+import { program } from './utils/cli.js';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
 

--- a/src/models/busFactor.ts
+++ b/src/models/busFactor.ts
@@ -1,0 +1,52 @@
+import { Octokit } from "octokit";
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+        auth: process.env.GITHUB_API_TOKEN
+export async function getBusFactor(url: string) {
+    const octokit = new Octokit({ 
+        auth: process.env.GITHUB_API_TOKEN
+    });
+
+    // extract repository name and its owner from the URL
+    const regex = /https:\/\/github\.com\/([^\/]+)\/([^\/]+)/;
+    const match = url.match(regex);
+    if (!match) {
+        throw new Error("Invalid URL");
+    }
+    const owner = match[1];
+    const repo = match[2];
+
+    // send the GET request for "list commits" API
+    const response = await octokit.request("GET /repos/{owner}/{repo}/commits", {
+        owner: owner,
+        repo: repo,
+        since: '2015-01-01T00:00:00Z'
+    });
+
+    // parse the response such that we create a dictionary of commit_author : number_of_commits mappings
+    const commits = response.data;
+    var commiters = new Map<string, number>();
+
+    commits.forEach((commit: any) => {
+        const author = commit.author.login;
+        if(!author) {
+            return;
+        }
+        else if(commiters.has(author)) {
+            commiters.set(author, (commiters.get(author) || 0) + 1);
+        }
+        else {
+            commiters.set(author, 1);
+        }
+    });
+    
+    // sort the dictionary by number_of_commits
+    const totalCommits = Array.from(commiters.values()).reduce((a, b) => a + b, 0);
+    var busFactor = 0;
+    for (const [author, commits] of commiters.entries()) {
+        busFactor += (commits / totalCommits) ** 2;
+    };
+
+    return busFactor.toFixed(3);
+};

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
-import { install } from "../commands/install";
-import { analyze } from "../commands/analyze";
+import { install } from "../commands/install.js";
+import { analyze } from "../commands/analyze.js";
 
 const program = new Command();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "ESNext",                                /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -75,7 +75,7 @@
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */


### PR DESCRIPTION
Take note of the import statements for files having the .js extension. Due to the usage of Octokit for GitHub APIs, I had to change the type of the project from commonjs to ES Modules, which required some changes (including that). 

For now I just created that function in /models - can be changed up to preference.

Metric designed to read GitHub URLs of specific format. I believe we have to handle npm links as well. The functionality to extract owners/repo names/etc. should probably be extracted to some other file in the future.

TODO: format of the response, handling all URLs, error responses, etc.